### PR TITLE
Fix/CloudTrail KMS Bucket Ref

### DIFF
--- a/mulit-account-aws-cloudtrail/aws-cloudtrail-enable/v1/product.template.yaml
+++ b/mulit-account-aws-cloudtrail/aws-cloudtrail-enable/v1/product.template.yaml
@@ -167,7 +167,7 @@ Resources:
                 - cloudtrail.amazonaws.com
             Action: s3:GetBucketAcl
             Resource:
-              - !Sub "arn:aws:s3:::${S3Bucket}"
+              - !Sub "arn:aws:s3:::${S3KmsBucket}"
           - Sid: AWSBucketDelivery
             Effect: Allow
             Principal:
@@ -179,7 +179,7 @@ Resources:
                         - ""
                         -
                           - "arn:aws:s3:::"
-                          - !Ref "S3Bucket"
+                          - !Ref "S3KmsBucket"
                           - "/AWSLogs/*/*"
 
   # Create buckets using S3-SSE keys for default encryption


### PR DESCRIPTION
*Issue #, if available:*
n/a
*Description of changes:*
Fixes the S3 bucket reference in the CloudTrail enable product when using aws:kms encryption

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
