### PR TITLE
Feature/gas factory govcloud

### DIFF
--- a/governance-at-scale-account-factory/account-bootstrap-shared/v4/README.md
+++ b/governance-at-scale-account-factory/account-bootstrap-shared/v4/README.md
@@ -1,0 +1,135 @@
+# account-bootstrap-shared
+# Description
+This product creates an AWS CodeBuild project that can be run to bootstrap an account. It also includes an AWS Lambda function that can be used to back a custom resource so that the CodeBuild project can be started from AWS CloudFormation
+
+## Usage
+This product should be provisioned in your Service Catalog Puppet account
+
+## Parameters
+The list of parameters for this template:
+
+### AssumableRoleArnInRootAccountForBootstrapping 
+*Type:* String  
+*Description:* The ARN of the assumable role from the root account 
+### GovernanceAtScaleAccountFactoryIAMRolePath 
+*Type:* String  
+*Description:* The path to use for IAM roles in this template 
+### GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName 
+*Type:* String  
+*Description:* The name to use for the IAM role that will be used by AWS CodeBuild to bootstrap spokes 
+### GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName 
+*Type:* String  
+*Description:* The name to use for the IAM role that will be used by AWS Lambda to trigger a bootstrap 
+
+## Resources
+The list of resources this template creates:
+
+### BootstrapperRole 
+*Type:* AWS::IAM::Role  
+*Description:* An IAM service role used by the **BootstrapperProject** AWS CodeBuild project
+### BootstrapperProject 
+*Type:* AWS::CodeBuild::Project  
+*Description:* An AWS CodeBuild project that:
+  - Installs `aws-service-catalog-puppet`
+  - Runs `servicecatalog-puppet bootstrap-spoke-as` 
+### BootstrapperProjectCustomResourceRole 
+*Type:* AWS::IAM::Role  
+*Description:* An IAM Role that is used as an execution role for the **BootstrapperProjectCustomResource** Lambda function
+### BootstrapperProjectCustomResource 
+*Type:* AWS::Serverless::Function  
+*Description:* An AWS Lambda function that runs an AWS CodeBuild project to bootstrap an account for Service Catalog Puppet. This Lambda function can be used to back a custom resource. You can get the ARN by checking the SSM Parameter
+```account-vending-bootstrapper-lambda```:
+```yaml
+Account:
+  Type: Custom::CustomResource
+  Properties:
+    ServiceToken: !Ref AccountVendingCreationLambda
+    Email: !Ref Email
+    AccountName: !Ref AccountName
+    OrganizationAccountAccessRole: !Ref OrganizationAccountAccessRole
+    IamUserAccessToBilling: !Ref IamUserAccessToBilling
+    TargetOU: !Ref TargetOU
+```
+
+## Outputs
+The list of outputs this template exposes:
+
+### GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn 
+*Description:* Outputs the BootstrapperProjectCustomResource ARN so others can use it
+  
+## Examples
+
+### Service Catalog Factory Portfolio
+The following example demonstrates how to create the `account-bootstrap-shared` Service Catalog Product in your Service Catalog Factory portfolio `yaml` file
+```yaml
+Portfolios:
+  Components:
+    - Description: account-bootstrap-shared
+      Distributor: CCOE
+      Name: account-bootstrap-shared
+      Owner: CCOE@Example.com
+      Source:
+        Configuration:
+          RepositoryName: account-bootstrap-shared
+        Provider: CodeCommit
+      BuildSpec: |
+        version: 0.2
+        phases:
+          install:
+            runtime-versions:
+              python: 3.8
+          build:
+            commands:
+              - pip install -r requirements.txt -t src
+            {% for region in ALL_REGIONS %}
+              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+            {% endfor %}
+        artifacts:
+          files:
+            - '*'
+            - '**/*'
+      SupportDescription: Find us on Slack or Wiki
+      SupportEmail: ccoe-support@Example.com
+      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+      Tags: []
+      Versions:
+        - Description: This product creates an AWS CodeBuild project that can be run to bootstrap an account. 
+            It also includes an AWS Lambda function that can be used to back a custom resource 
+            so that the CodeBuild project can be started from AWS CloudFormation
+          Name: v3
+          Source:
+            Provider: CodeCommit
+            Configuration:
+              BranchName: v3
+              RepositoryName: account-bootstrap-shared
+```
+
+### Service Catalog Puppet Launch
+The following example demonstrates how to provision the `account-bootstrap-shared` Service Catalog Product in your Service Catalog Puppet `manifest.yaml` file
+```yaml
+launches:
+  account-bootstrap-shared:
+    depends_on:
+      - account-bootstrap-shared-org-bootstrap
+    deploy_to:
+      tags:
+        - regions: default_region
+          tag: scope:puppet_account
+    outputs:
+      ssm:
+        - param_name: /governance-at-scale-account-factory/account-bootstrap-shared/GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn
+          stack_output: GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn
+    parameters:
+      AssumableRoleArnInRootAccountForBootstrapping:
+        ssm:
+          name: /governance-at-scale-account-factory/account-bootstrap-shared-org-bootstrap/AssumableRoleArnInRootAccountForBootstrapping
+      GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName:
+        default: AccountBootstrapSharedBootstrapperIAMRoleName
+      GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName:
+        default: AccountBootstrapSharedCustomResourceIAMRoleName
+      GovernanceAtScaleAccountFactoryIAMRolePath:
+        default: /AccountFactoryIAMRolePath/
+    portfolio: demo-central-it-team-portfolio
+    product: account-bootstrap-shared
+    version: v3
+```

--- a/governance-at-scale-account-factory/account-bootstrap-shared/v4/product.template.yaml
+++ b/governance-at-scale-account-factory/account-bootstrap-shared/v4/product.template.yaml
@@ -1,0 +1,154 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: |
+  This product creates an AWS CodeBuild project that can be run to bootstrap an account. 
+  It also includes an AWS Lambda function that can be used to back a custom resource 
+  so that the CodeBuild project can be started from AWS CloudFormation
+  {"framework": "servicecatalog-products", "role": "product", "product-set": "governance-at-scale-account-factory", "product": "account-bootstrap-shared", "version": "v3"}
+
+Parameters:
+  AssumableRoleArnInRootAccountForBootstrapping:
+    Description: The ARN of the assumable role from the root account 
+    Type: String
+  GovernanceAtScaleAccountFactoryIAMRolePath:
+    Description: The path to use for IAM roles in this template
+    Type: String
+  GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName:
+    Description: The name to use for the IAM role that will be used by AWS CodeBuild to bootstrap spokes
+    Type: String
+  GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName:
+    Description: The name to use for the IAM role that will be used by AWS Lambda to trigger a bootstrap
+    Type: String
+
+Resources:
+  BootstrapperRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: An IAM service role used by the BootstrapperProject AWS CodeBuild project
+      RoleName: !Ref GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName
+      Path: !Ref GovernanceAtScaleAccountFactoryIAMRolePath
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "codebuild.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+
+  BootstrapperProject:
+    Type: AWS::CodeBuild::Project
+    Description: |
+      An AWS CodeBuild project that:
+        - Installs aws-service-catalog-puppet
+        - Runs servicecatalog-puppet bootstrap-spoke-as
+    Properties:
+      Name: servicecatalog-puppet-single-account-bootstrapper
+      Description: "Bootstraps an account for use with ServiceCatalog-Puppet"
+      ServiceRole: !GetAtt BootstrapperRole.Arn
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Environment:
+        Type: linuxContainer
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:4.0
+        EnvironmentVariables:
+          - Name: PUPPET_ACCOUNT_ID
+            Type: PLAINTEXT
+            Value: CHANGE_ME
+          - Name: ORGANIZATION_ACCOUNT_ACCESS_ROLE_ARN
+            Type: PLAINTEXT
+            Value: CHANGE_ME
+          - Name: VERSION
+            Type: PLAINTEXT
+            Value: CHANGE_ME
+          - Name: ASSUMABLE_ROLE_IN_ROOT_ACCOUNT
+            Type: PLAINTEXT
+            Value: !Ref AssumableRoleArnInRootAccountForBootstrapping
+          - Name: PUPPET_ROLE_NAME
+            Type: PLAINTEXT
+            Value: CHANGE_ME
+          - Name: PUPPET_ROLE_PATH
+            Type: PLAINTEXT
+            Value: CHANGE_ME
+      Source:
+        Type: NO_SOURCE
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.8
+              commands:
+                - pip install aws-service-catalog-puppet==${VERSION}
+            build:
+              commands:
+                - servicecatalog-puppet bootstrap-spoke-as ${PUPPET_ACCOUNT_ID} ${ASSUMABLE_ROLE_IN_ROOT_ACCOUNT} ${ORGANIZATION_ACCOUNT_ACCESS_ROLE_ARN} --puppet-role-name ${PUPPET_ROLE_NAME} --puppet-role-path ${PUPPET_ROLE_PATH}
+      TimeoutInMinutes: 30
+
+  BootstrapperProjectCustomResourceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: | 
+        An IAM Role that is used as an execution role for the 
+        BootstrapperProjectCustomResource Lambda function
+      RoleName: !Ref GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName
+      Path: !Ref GovernanceAtScaleAccountFactoryIAMRolePath
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AdministratorAccess
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action:
+              - "sts:AssumeRole"
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "sts:AssumeRole"
+
+  BootstrapperProjectCustomResource:
+    Type: AWS::Serverless::Function
+    Description: |
+      An AWS Lambda function that runs an AWS CodeBuild project to bootstrap an account for 
+      Service Catalog Puppet. This Lambda function can be used to back a custom resource. 
+      You can get the ARN by checking the SSM Parameter
+      ```account-vending-bootstrapper-lambda```:
+      ```yaml
+      Account:
+        Type: Custom::CustomResource
+        Properties:
+          ServiceToken: !Ref AccountVendingCreationLambda
+          Email: !Ref Email
+          AccountName: !Ref AccountName
+          OrganizationAccountAccessRole: !Ref OrganizationAccountAccessRole
+          IamUserAccessToBilling: !Ref IamUserAccessToBilling
+          TargetOU: !Ref TargetOU
+      ```
+    Properties:
+      CodeUri: ./src
+      Handler: handler.handler
+      Description: Lambda for accepting shares
+      Role: !GetAtt BootstrapperProjectCustomResourceRole.Arn
+      Runtime: python3.8
+      Timeout: 900
+      Environment:
+        Variables:
+          BOOTSTRAPPER_PROJECT_NAME: !Ref BootstrapperProject
+          ASSUMABLE_ROLE_IN_ROOT_ACCOUNT_ARN: !Ref AssumableRoleArnInRootAccountForBootstrapping
+
+Outputs:
+  GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn:
+    Description: |
+      Outputs the BootstrapperProjectCustomResource Arn so others can use it
+    Value: !GetAtt BootstrapperProjectCustomResource.Arn

--- a/governance-at-scale-account-factory/account-bootstrap-shared/v4/requirements.txt
+++ b/governance-at-scale-account-factory/account-bootstrap-shared/v4/requirements.txt
@@ -1,0 +1,1 @@
+better-boto==0.25.0

--- a/governance-at-scale-account-factory/account-bootstrap-shared/v4/src/handler.py
+++ b/governance-at-scale-account-factory/account-bootstrap-shared/v4/src/handler.py
@@ -1,0 +1,178 @@
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json, logging, time
+from urllib.request import Request, urlopen
+from betterboto import client as betterboto_client
+import os
+import traceback
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logging.basicConfig(
+    format="%(levelname)s %(threadName)s [%(filename)s:%(lineno)d] %(message)s",
+    datefmt="%Y-%m-%d:%H:%M:%S",
+    level=logging.INFO,
+)
+
+
+def handler(event, context):
+    request_type = event["RequestType"]
+    try:
+        logger.info(request_type)
+        if request_type == "Create":
+            target_account_id = event.get("ResourceProperties").get("TargetAccountId")
+            puppet_account_id = event.get("ResourceProperties").get("PuppetAccountId")
+            organization_account_access_role_name = event.get("ResourceProperties").get(
+                "OrganizationAccountAccessRoleName"
+            )
+            puppet_account_access_role_name = event.get("ResourceProperties").get(
+                "PuppetAccountAccessRoleName"
+            )
+
+            partition = event.get("ResourceProperties").get("AccountPartition")
+
+            organization_account_access_role_arn = "arn:{}:iam::{}:role/{}".format(
+                partition, target_account_id, organization_account_access_role_name
+            )
+            puppet_account_access_role_arn = "arn:{}:iam::{}:role/{}".format(
+                partition, puppet_account_id, puppet_account_access_role_name
+            )
+
+            with betterboto_client.CrossAccountClientContextManager(
+                "ssm", puppet_account_access_role_arn, "assumable_org_role"
+            ) as ssm:
+                puppet_version = (
+                    ssm.get_parameter(Name="service-catalog-puppet-version")
+                    .get("Parameter")
+                    .get("Value")
+                )
+                puppet_role_name = (
+                    ssm.get_parameter(Name="/servicecatalog-puppet/puppet-role/name")
+                    .get("Parameter")
+                    .get("Value")
+                )
+                puppet_role_path = (
+                    ssm.get_parameter(Name="/servicecatalog-puppet/puppet-role/path")
+                    .get("Parameter")
+                    .get("Value")
+                )
+                assumable_role_in_root_account = os.environ.get(
+                    "ASSUMABLE_ROLE_IN_ROOT_ACCOUNT_ARN"
+                )
+
+            bootstrapper_project_name = os.environ.get("BOOTSTRAPPER_PROJECT_NAME")
+
+            with betterboto_client.CrossAccountClientContextManager(
+                "codebuild", puppet_account_access_role_arn, "assumable_org_role"
+            ) as codebuild:
+                bootstrapper_build = codebuild.start_build_and_wait_for_completion(
+                    projectName=bootstrapper_project_name,
+                    environmentVariablesOverride=[
+                        {
+                            "name": "ASSUMABLE_ROLE_IN_ROOT_ACCOUNT",
+                            "value": assumable_role_in_root_account,
+                            "type": "PLAINTEXT",
+                        },
+                        {
+                            "name": "VERSION",
+                            "value": puppet_version,
+                            "type": "PLAINTEXT",
+                        },
+                        {
+                            "name": "PUPPET_ACCOUNT_ID",
+                            "value": puppet_account_id,
+                            "type": "PLAINTEXT",
+                        },
+                        {
+                            "name": "ORGANIZATION_ACCOUNT_ACCESS_ROLE_ARN",
+                            "value": organization_account_access_role_arn,
+                            "type": "PLAINTEXT",
+                        },
+                        {
+                            "name": "PUPPET_ROLE_NAME",
+                            "value": puppet_role_name,
+                            "type": "PLAINTEXT",
+                        },
+                        {
+                            "name": "PUPPET_ROLE_PATH",
+                            "value": puppet_role_path,
+                            "type": "PLAINTEXT",
+                        },
+                    ],
+                )
+                final_status = bootstrapper_build.get("buildStatus")
+
+                if final_status == "SUCCEEDED":
+                    puppet_run_build = codebuild.start_build(
+                        projectName="servicecatalog-puppet-single-account-run-with-callback",
+                        environmentVariablesOverride=[
+                            {
+                                "name": "SINGLE_ACCOUNT_ID",
+                                "value": target_account_id,
+                                "type": "PLAINTEXT",
+                            },
+                            {
+                                "name": "CALLBACK_URL",
+                                "value": event.get("ResourceProperties").get("Handle"),
+                                "type": "PLAINTEXT",
+                            },
+                        ],
+                    ).get("build")
+
+                    send_response(
+                        event,
+                        context,
+                        "SUCCESS",
+                        {
+                            "Message": "Resource creation successful!",
+                            "puppet_run_build_id": puppet_run_build.get("id"),
+                            "bootstrapper_build_id": bootstrapper_build.get("id"),
+                        },
+                    )
+                else:
+                    logger.error(
+                        "Errored check the logs: {}".format(
+                            bootstrapper_build.get("logs").get("deepLink")
+                        )
+                    )
+                    send_response(
+                        event,
+                        context,
+                        "FAILED",
+                        {
+                            "Message": "Bootstrap errored, check the logs: {}".format(
+                                bootstrapper_build.get("logs").get("deepLink")
+                            ),
+                        },
+                    )
+
+        elif request_type == "Update":
+            send_response(event, context, "SUCCESS", {"Message": "Updated"})
+        elif request_type == "Delete":
+            send_response(event, context, "SUCCESS", {"Message": "Deleted"})
+        else:
+            send_response(event, context, "FAILED", {"Message": "Unexpected"})
+    except Exception as ex:
+        logger.error(ex)
+        traceback.print_tb(ex.__traceback__)
+        send_response(event, context, "FAILED", {"Message": "Exception"})
+
+
+def send_response(e, c, rs, rd):
+    r = json.dumps(
+        {
+            "Status": rs,
+            "Reason": "CloudWatch Log Stream: " + c.log_stream_name,
+            "PhysicalResourceId": c.log_stream_name,
+            "StackId": e["StackId"],
+            "RequestId": e["RequestId"],
+            "LogicalResourceId": e["LogicalResourceId"],
+            "Data": rd,
+        }
+    )
+    d = str.encode(r)
+    h = {"content-type": "", "content-length": str(len(d))}
+    req = Request(e["ResponseURL"], data=d, method="PUT", headers=h)
+    r = urlopen(req)
+    logger.info("Status message: {} {}".format(r.msg, r.getcode()))

--- a/governance-at-scale-account-factory/account-creation-notifier-cfh-handler/v1/product.template.yaml
+++ b/governance-at-scale-account-factory/account-creation-notifier-cfh-handler/v1/product.template.yaml
@@ -27,17 +27,17 @@ Parameters:
 
 Resources:
   Subscription:
+    Description: A subscription to the provided SNS topic that will trigger the Function AWS Lambda Function
     Type: AWS::SNS::Subscription
     Properties:
-      Description: A subscription to the provided SNS topic that will trigger the Function AWS Lambda Function
       TopicArn: !Ref AccountCreateUpdateNotifierTopicArn
       Endpoint: !GetAtt Function.Arn
       Protocol: lambda
 
   Permission:
+    Description: The permission that allows the provided SNS topic to invoke the AWS Lambda function
     Type: AWS::Lambda::Permission
     Properties:
-      Description: The permission that allows the provided SNS topic to invoke the AWS Lambda function
       Action: lambda:InvokeFunction
       FunctionName: !Ref Function
       Principal: "sns.amazonaws.com"
@@ -92,5 +92,3 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-
-

--- a/governance-at-scale-account-factory/account-puppet-org-bootstrap/v1/README.md
+++ b/governance-at-scale-account-factory/account-puppet-org-bootstrap/v1/README.md
@@ -1,16 +1,16 @@
-# govcloud-account-onboard-puppet-bootstrap
+# account-puppet-org-bootstrap
 # Description
-This product creates the IAM role that **govcloud-account-onboard** requires in order to bootstrap a new GovCloud account as a spoke of the GovCloud Service Catalog Puppet account
+This product creates the IAM role that is required in order to bootstrap a new account as a spoke of the Puppet account
  
 ## Usage
-This product is intended to be used as part of the GovCloud account creation process. It must be provisioned in the GovCloud Service Catalog Puppet account
+This product is intended to be used as part of both the GovCloud and Commercial account creation process. It must be provisioned in the corresponding Service Catalog Puppet account
 
 ## Parameters
 The list of parameters for this template:
 
 ### OrganizationRootAccountId 
 *Type:* String  
-*Description:* The account ID of the Organization root in GovCloud
+*Description:* The account ID of the Organization root 
 ### OrganizationAccountAccessRole 
 *Type:* String  
 *Default:* OrganizationAccountAccessRole  
@@ -24,7 +24,7 @@ The list of resources this template creates:
 
 ### AssumableRoleInPuppetAccount 
 *Type:* AWS::IAM::Role  
-*Description:* An assumable IAM Role that allows the govcloud-account-onboard product to bootstrap accounts with Service Catalog Puppet
+*Description:* An assumable IAM Role that allows the govcloud-account-onboard and account-bootstrap-shared products to bootstrap accounts with Service Catalog Puppet
  
 
 ## Outputs
@@ -36,31 +36,31 @@ The list of outputs this template exposes:
 ## Examples
 
 ### Service Catalog Factory Portfolio
-The following example demonstrates how to create the `govcloud-account-onboard-puppet-bootstrap` Service Catalog Product in your Service Catalog Factory portfolio `yaml` file
+The following example demonstrates how to create the `account-puppet-org-bootstrap` Service Catalog Product in your Service Catalog Factory portfolio `yaml` file
 ```yaml
 Portfolios:
   Components:
-    - Description: govcloud-account-onboard-puppet-bootstrap
+    - Description: account-puppet-org-bootstrap
       Distributor: CCOE
-      Name: govcloud-account-onboard-puppet-bootstrap
+      Name: account-puppet-org-bootstrap
       Owner: CCOE@Example.com
       Source:
         Configuration:
-          RepositoryName: govcloud-account-onboard-puppet-bootstrap
+          RepositoryName: account-puppet-org-bootstrap
         Provider: CodeCommit
       SupportDescription: Find us on Slack or Wiki
       SupportEmail: ccoe-support@Example.com
       SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
       Versions:
-        - Description: This product creates the IAM role that govcloud-account-onboard requires 
-            in order to bootstrap a new GovCloud account as a spoke of the GovCloud Service 
-            Catalog Puppet account
+        - Description: This product creates the IAM role that govcloud-account-onboard and 
+            account-bootstrap-shared require in order to bootstrap a new account as a 
+            spoke of the Service Catalog Puppet account
           Name: v1
           Source:
             Provider: CodeCommit
             Configuration:
               BranchName: v1
-              RepositoryName: govcloud-account-onboard-puppet-bootstrap
+              RepositoryName: account-puppet-org-bootstrap
       ProviderName: ccoe
       Tags:
         - Key: team
@@ -68,10 +68,10 @@ Portfolios:
 ```
 
 ### Service Catalog Puppet Launch
-The following example demonstrates how to provision the `govcloud-account-onboard-puppet-bootstrap` Service Catalog Product in your Service Catalog Puppet `manifest.yaml` file.
+The following example demonstrates how to provision the `account-puppet-org-bootstrap` Service Catalog Product in your Service Catalog Puppet `manifest.yaml` file.
 ```yaml
 launches:
-  govcloud-account-onboard-puppet-bootstrap:
+  account-puppet-org-bootstrap:
     parameters:
       OrganizationRootAccountId:
         default: SET_ME
@@ -80,7 +80,7 @@ launches:
       AccountOnboardPuppetRoleName:
         default: PuppetAccountAccessRole
     portfolio: demo-central-it-team-portfolio
-    product: govcloud-account-onboard-puppet-bootstrap
+    product: account-puppet-org-bootstrap
     version: v1
     deploy_to:
       tags:

--- a/governance-at-scale-account-factory/account-puppet-org-bootstrap/v1/product.template.yaml
+++ b/governance-at-scale-account-factory/account-puppet-org-bootstrap/v1/product.template.yaml
@@ -1,15 +1,14 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Description: |
-  This product creates the IAM role that govcloud-account-onboard requires in order to 
-  bootstrap a new GovCloud account as a spoke of the GovCloud Service Catalog Puppet account
-  {"framework": "servicecatalog-products", "role": "product", "product-set": "governance-at-scale-account-factory", "product": "govcloud-account-onboard-puppet-bootstrap", "version": "v1"}
+  This product creates the IAM role that is required in order to bootstrap a new account as a spoke of the Puppet account
+  {"framework": "servicecatalog-products", "role": "product", "product-set": "governance-at-scale-account-factory", "product": "account-puppet-org-bootstrap", "version": "v1"}
 
 Parameters:
   OrganizationRootAccountId:
-    Description: The account ID of the Organization root in GovCloud
+    Description: The account ID of the Organization root
     Type: String
   OrganizationAccountAccessRole:
     Description: Name of the IAM role used to access cross accounts for AWS Organizations usage
@@ -25,8 +24,9 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Description: |
-        An assumable IAM Role that allows the govcloud-account-onboard product to bootstrap 
-        accounts with Service Catalog Puppet
+        An assumable IAM Role that allows the govcloud-account-onboard and 
+        account-bootstrap-shared products to bootstrap accounts with 
+        Service Catalog Puppet
       RoleName: !Ref AccountOnboardPuppetRoleName
       Path: /
       Policies:
@@ -38,13 +38,13 @@ Resources:
                 Effect: Allow
                 Action:
                   - ssm:GetParameter
-                Resource: '*'
+                Resource: "*"
               - Sid: CodeBuildStartBuilds
                 Effect: Allow
                 Action:
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
-                Resource: '*'
+                Resource: "*"
               - Effect: Allow
                 Action:
                   - sts:AssumeRole

--- a/governance-at-scale-account-factory/aws-service-catalog-account-creation/v4/README.md
+++ b/governance-at-scale-account-factory/aws-service-catalog-account-creation/v4/README.md
@@ -1,0 +1,172 @@
+# aws-service-catalog-account-creation
+# Description
+This product is used to create a commercial AWS Account and bootstrap it using `aws-service-catalog-puppet` so you can provision products into the account
+ 
+## Usage
+Before provisioning this product, the account-bootstrap-shared product and the account-creation-shared product must both be provisioned into the same account, These two products build some resources needed for this product to work. They also provision the SSM parameters with the correct ARNs so this works without copy and pasting. 
+
+## Parameters
+The list of parameters for this template:
+
+### Email 
+*Type:* String  
+*Description:* The email address to use for the commerical account that is to be created
+### AccountName 
+*Type:* String  
+*Description:* The name to use for the account that is to be created 
+### OrganizationAccountAccessRole 
+*Type:* String  
+*Default:* OrganizationAccountAccessRole  
+*Description:* The name of the role to be created in the account that allows Organizations access 
+### IamUserAccessToBilling 
+*Type:* String  
+*Default:* ALLOW  
+*Descriptipon:* If set to ALLOW, this enables IAM users to access account billing information if they have the required permissions. If set to DENY, only the root user of the new account can access account billing information
+### AccountGroup 
+*Type:* String  
+*Description:* Which platform does the account belong to 
+### AccountType 
+*Type:* String  
+*Description:* Which stage of the SDLC is the account going to be used for 
+### GovernanceAtScaleAccountFactoryAccountCreationCRArn 
+*Type:* String  
+*Description:* The ARN for the AWS Lambda function that creates the account
+### GovernanceAtScaleAccountFactoryMoveToOUArn 
+*Type:* String  
+*Description:* The ARN of the AWS Lambda function that moves the new commercial account to the correct organizational unit
+### GovernanceAtScaleAccountFactoryAccountWaiterArn 
+*Type:* String  
+*Description:* The ARN of the AWS Lambda function that waits for CodeBuild and CloudFormation to become available in the new commercial account
+### GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn 
+*Type:* String  
+*Description:* The ARN of the AWS Lambda function that will bootstrap the new commerical account as a spoke of the current Service Catalog Puppet account
+### GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn 
+*Type:* String  
+*Description:* The ARN of the AWS Lambda function that converts the account group and account type to the correct organizational unit
+### GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn 
+*Type:* String  
+*Description:* The ARN of the AWS Lambda function that will dispatch SNS notifications on account creation
+### ServiceCatalogPuppetVersion
+*Type:* String  
+*Description:* The version of Service Catalog Puppet in use
+### PuppetAccountId
+*Type:* String  
+*Description:* The account ID for the Commercial account where Service Catalog Puppet is installed
+### PuppetAccountAccessRoleName
+*Type:* String
+*Description:* The name of the role to that allows the current account to bootstrap a spoke against the Puppet account
+
+## Resources
+The list of resources this template creates:
+
+### OUDetails 
+*Type:* Custom::Resource  
+*Description:* A custom resource using the **GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn** AWS Lambda function to convert the account type and group into the correct organizational unit (OU)
+### Account 
+*Type:* Custom::CustomResource  
+*Description:* A custom resource using the **GovernanceAtScaleAccountFactoryAccountCreationCRArn** AWS Lambda function to create the new commercial account
+### MoveToOU 
+*Type:* Custom::CustomResource  
+*Description:* A custom resource using the **GovernanceAtScaleAccountFactoryMoveToOUArn** AWS Lambda function to move the new account to the correct OU
+### AccountWaiter1 
+*Type:* Custom::CustomResource  
+*Description:* A custom resource using the **GovernanceAtScaleAccountFactoryAccountWaiterArn** AWS Lambda function to wait for CodeBuild and CloudFormation to become available in the new account
+### Notifier 
+*Type:* Custom::Resource  
+*Description:* A custom resource using the **GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn** AWS Lambda function to send a notification when the new account is created
+### Bootstrap 
+*Type:* Custom::CustomResource  
+*Description:* A custom resource using the **GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn** AWS Lambda function to bootstrap the new account
+
+## Outputs
+The list of outputs this template exposes:
+
+### AccountId 
+*Description:* The ID of the new account
+   
+## Examples
+
+### Service Catalog Factory Portfolio
+The following example demonstrates how to create the `aws-service-catalog-account-creation` Service Catalog Product in your Service Catalog Factory portfolio `yaml` file
+```yaml
+Portfolios:
+  Components:
+    - Description: aws-service-catalog-account-creation
+      Distributor: CCOE
+      Name: aws-service-catalog-account-creation
+      Owner: CCOE@Example.com
+      Source:
+        Configuration:
+          RepositoryName: aws-service-catalog-account-creation
+        Provider: CodeCommit
+      SupportDescription: Find us on Slack or Wiki
+      SupportEmail: ccoe-support@Example.com
+      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+      Versions:
+        - Description: This product is used to create a commercial AWS Account and bootstrap 
+            it using `aws-service-catalog-puppet` so you can provision products into the account
+          Name: v3
+          Source:
+            Provider: CodeCommit
+            Configuration:
+              BranchName: v3
+              RepositoryName: aws-service-catalog-account-creation
+      ProviderName: ccoe
+      Tags:
+        - Key: team
+          Value: ccoe
+```
+
+### Service Catalog Puppet Launch
+The following example demonstrates how to provision the `aws-service-catalog-account-creation` Service Catalog Product in your Service Catalog Puppet `manifest.yaml` file. This product is most commonly provisioned through Service Catalog Products UI in the AWS Console.
+```yaml
+launches:
+  aws-service-catalog-account-factory-account:
+    depends_on:
+      - account-type-to-organizational-unit-chooser
+      - account-details
+      - account-create-update-notifier
+      - account-bootstrap-shared
+      - account-waiter
+      - move-to-ou
+    deploy_to:
+      tags:
+        - regions: default_region
+          tag: scope:puppet_account
+    parameters:
+      Email:
+        default: emailme@example.com
+      AccountGroup:
+        default: workloads
+      AccountName:
+        default: devaccountforteamx
+      AccountType:
+        default: dev
+      OrganizationAccountAccessRole:
+        default: OrganizationAccountAccessRole
+      IamUserAccessToBilling:
+        default: ALLOW
+      GovernanceAtScaleAccountFactoryAccountCreationCRArn:
+        ssm:
+          name: /governance-at-scale-account-factory/account-creation-shared/GovernanceAtScaleAccountFactoryAccountCreationCRArn
+      GovernanceAtScaleAccountFactoryMoveToOUArn:
+        ssm:
+          name: /governance-at-scale-account-factory/move-to-ou/GovernanceAtScaleAccountFactoryMoveToOUCRArn
+      GovernanceAtScaleAccountFactoryAccountWaiterArn:
+        ssm:
+          name: /governance-at-scale-account-factory/account-waiter/GovernanceAtScaleAccountFactoryAccountWaiterCRArn
+      GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn:
+        ssm:
+          name: /governance-at-scale-account-factory/account-bootstrap-shared/GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn
+      GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn:
+        ssm:
+          name: /governance-at-scale-account-factory/account-type-to-organizational-unit-chooser/GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn
+      GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn:
+        ssm:
+          name: /governance-at-scale-account-factory/account-create-update-notifier/GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn
+      ServiceCatalogPuppetVersion:
+        default: 0.91.0
+    portfolio: demo-central-it-team-portfolio
+    product: aws-service-catalog-account-creation
+    version: v3
+```

--- a/governance-at-scale-account-factory/aws-service-catalog-account-creation/v4/product.template.yaml
+++ b/governance-at-scale-account-factory/aws-service-catalog-account-creation/v4/product.template.yaml
@@ -1,12 +1,11 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: "2010-09-09"
 Description: |
-  This product is used to create a new GovCloud account and the linked commercial AWS Accounts. 
-  The accounts will be moved to the organizational unit (OU) based on the provided account groups 
-  and account types. The new accounts will be bootstrapped with the Service Catalog Puppet 
-  account in the corresponding partition.
-  {"framework": "servicecatalog-products", "role": "product", "product-set": "governance-at-scale-account-factory", "product": "aws-service-catalog-govcloud-account-creation", "version": "v1"}
+  This product is used to create a commercial AWS Account and bootstrap it using `aws-service-catalog-puppet` so you can provision products into the account
+  {"framework": "servicecatalog-products", "role": "product", "product-set": "governance-at-scale-account-factory", "product": "aws-service-catalog-account-creation", "version": "v3"}
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -15,27 +14,15 @@ Metadata:
         Parameters:
           - AccountName
           - Email
-          - OrganizationAccountAccessRole
-      - Label:
-          default: Commercial Account Specifics
-        Parameters:
           - AccountGroup
           - AccountType
+          - OrganizationAccountAccessRole
           - IamUserAccessToBilling
-          - PuppetAccountId
-          - PuppetAccountAccessRoleName
-      - Label:
-          default: GovCloud Account Specifics
-        Parameters:
-          - GovCloudAccountGroup
-          - GovCloudAccountType
-          - GovCloudPuppetAccountId
       - Label:
           default: Lambda ARNs
         Parameters:
           - GovernanceAtScaleAccountFactoryAccountCreationCRArn
           - GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn
-          - GovernanceAtScaleAccountFactoryGovCloudAccountCreateUpdateNotifierCRArn
           - GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn
           - GovernanceAtScaleAccountFactoryMoveToOUArn
           - GovernanceAtScaleAccountFactoryAccountWaiterArn
@@ -44,19 +31,17 @@ Metadata:
           default: Service Catalog Puppet
         Parameters:
           - ServiceCatalogPuppetVersion
+          - PuppetAccountId
+          - PuppetAccountAccessRoleName
     ParameterLabels:
       AccountName:
         default: Account Name
       Email:
         default: Account Email Address
       AccountGroup:
-        default: Commercial Account Group
+        default: Account Group
       AccountType:
-        default: Commercial Account Type
-      GovCloudAccountGroup:
-        default: GovCloud Account Group
-      GovCloudAccountType:
-        default: GovCloud Account Type
+        default: Account Type
       IamUserAccessToBilling:
         default: User Access to Billing
       OrganizationAccountAccessRole:
@@ -64,9 +49,7 @@ Metadata:
       GovernanceAtScaleAccountFactoryAccountCreationCRArn:
         default: Account Creation Lambda ARN
       GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn:
-        default: Commericial Account Notifier ARN
-      GovernanceAtScaleAccountFactoryGovCloudAccountCreateUpdateNotifierCRArn:
-        default: GovCloud Account Notifier ARN
+        default: Account Notifier ARN
       GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn:
         default: Account Type to OU Lambda ARN
       GovernanceAtScaleAccountFactoryMoveToOUArn:
@@ -81,16 +64,14 @@ Metadata:
         default: Commercial Puppet Account ID
       PuppetAccountAccessRoleName:
         default: Puppet Account Access IAM Role Name
-      GovCloudPuppetAccountId:
-        default: GovCloud Puppet Account ID
 
 Parameters:
   Email:
     Type: String
-    Description: The email address to use for the GovCloud and Commerical accounts that are to be created
+    Description: The email address to use for the account that is to be created
   AccountName:
     Type: String
-    Description: The name to use for the accounts that are to be created
+    Description: The name to use for the account that is to be created
   OrganizationAccountAccessRole:
     Type: String
     Default: OrganizationAccountAccessRole
@@ -99,7 +80,6 @@ Parameters:
     Type: String
     Default: "ALLOW"
     AllowedValues: ["ALLOW", "DENY"]
-    Description: If set to ALLOW, the new linked account in the commercial Region enables IAM users to access account billing information if they have the required permissions. If set to DENY, only the root user of the new account can access account billing information.
   AccountGroup:
     Type: String
     Description: >-
@@ -117,44 +97,24 @@ Parameters:
       - test
       - preprod
       - prod
-  GovCloudAccountGroup:
-    Type: String
-    Description: >-
-      Which platform does the account belong to
-    AllowedValues:
-      - Security
-      - Infrastructure
-      - Workload
-  GovCloudAccountType:
-    Type: String
-    Description: >-
-      Which stage of the SDLC is the account going to be used for
-    AllowedValues:
-      - dev
-      - test
-      - preprod
-      - prod
   GovernanceAtScaleAccountFactoryAccountCreationCRArn:
     Type: String
-    Description: The ARN for the AWS Lambda function that creates the accounts
+    Description: The ARN of the account creation lambda
   GovernanceAtScaleAccountFactoryMoveToOUArn:
     Type: String
-    Description: The ARN of the AWS Lambda function that moves the new commercial account to the correct organizational unit
+    Description: The ARN of the move to ou lambda
   GovernanceAtScaleAccountFactoryAccountWaiterArn:
     Type: String
-    Description: The ARN of the AWS Lambda function that waits for CodeBuild and CloudFormation to become available in the new commercial account
+    Description: The ARN of the move to ou lambda
   GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn:
     Type: String
-    Description: The ARN of the AWS Lambda function that will bootstrap the new commerical account as a spoke of the current Service Catalog Puppet account
+    Description: The ARN of the account bootstrapping lambda
   GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn:
     Type: String
-    Description: The ARN of the laAWS Lambda functionmbda that converts the account group and account type to the correct organizational unit
+    Description: The ARN of the lambda that converts group and type to Arn
   GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn:
     Type: String
-    Description: The ARN of the AWS Lambda function that will dispatch SNS notifications on account creation of the Commerical account
-  GovernanceAtScaleAccountFactoryGovCloudAccountCreateUpdateNotifierCRArn:
-    Type: String
-    Description: The ARN of the AWS Lambda function that will dispatch SNS notifications on account creation of the GovCloud account
+    Description: The ARN of the lambda that will dispatch SNS notifications on account creation / update
   ServiceCatalogPuppetVersion:
     Type: String
     Description: The version of Service Catalog Puppet in use
@@ -165,9 +125,6 @@ Parameters:
     Type: String
     Default: PuppetAccountAccessRole
     Description: The name of the role to that allows the current account to bootstrap a spoke against the Puppet account
-  GovCloudPuppetAccountId:
-    Type: String
-    Description: Account ID for the GovCloud Service Catalog Puppet account
 
 Resources:
   OUDetails:
@@ -176,43 +133,29 @@ Resources:
     Description: |
       A custom resource using the GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn 
       AWS Lambda function to convert the account type and group into the correct 
-      organizational unit (OU) for the Commercial account
+      organizational unit (OU)
     Properties:
       ServiceToken: !Ref GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn
       AccountType: !Ref AccountType
       AccountGroup: !Ref AccountGroup
       AccountPartition: Commercial
 
-  GovCloudOUDetails:
-    Type: Custom::Resource
-    DeletionPolicy: Retain
-    Description: |
-      A custom resource using the GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn 
-      AWS Lambda function to convert the account type and group into the correct 
-      organizational unit (OU) for the GovCloud account
-    Properties:
-      ServiceToken: !Ref GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn
-      AccountType: !Ref GovCloudAccountType
-      AccountGroup: !Ref GovCloudAccountGroup
-      AccountPartition: GovCloud
-
   Account:
     Type: Custom::Resource
     Description: |
       A custom resource using the GovernanceAtScaleAccountFactoryAccountCreationCRArn 
-      AWS Lambda function to create the new Commercial and GovCloud accounts
+      AWS Lambda function to create the new account
     Properties:
       ServiceToken: !Ref GovernanceAtScaleAccountFactoryAccountCreationCRArn
       Email: !Ref Email
       AccountName: !Ref AccountName
       IamUserAccessToBilling: !Ref IamUserAccessToBilling
-      AccountPartition: GovCloud
 
   MoveToOU:
     Type: Custom::Resource
     Description: |
       A custom resource using the GovernanceAtScaleAccountFactoryMoveToOUArn 
-      AWS Lambda function to move the new Commercial account to the correct OU
+      AWS Lambda function to move the new account to the correct OU
     Properties:
       ServiceToken: !Ref GovernanceAtScaleAccountFactoryMoveToOUArn
       AccountType: !Ref AccountType
@@ -229,7 +172,7 @@ Resources:
     Description: |
       A custom resource using the GovernanceAtScaleAccountFactoryAccountWaiterArn 
       AWS Lambda function to wait for CodeBuild and CloudFormation to become 
-      available in the new Commercial account
+      available in the new account
     Properties:
       ServiceToken: !Ref GovernanceAtScaleAccountFactoryAccountWaiterArn
       AccountId: !GetAtt Account.account_id
@@ -249,34 +192,14 @@ Resources:
     DeletionPolicy: Retain
     Description: |
       A custom resource using the GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn 
-      AWS Lambda function to send a notification when the new Commercial account is created
+      AWS Lambda function to send a notification when the new account is created
     Properties:
       ServiceToken: !Ref GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn
       AccountName: !Ref AccountName
       AccountEmail: !Ref Email
       ManagedOrganizationalUnit: !GetAtt OUDetails.OrganizationalUnitName
       AccountId: !GetAtt Account.account_id
-      PuppetAccountId: !Ref PuppetAccountId
       AccountPartition: Commercial
-
-  GovCloudNotifier:
-    Type: Custom::Resource
-    DeletionPolicy: Retain
-    Description: |
-      A custom resource using the GovernanceAtScaleAccountFactoryGovCloudAccountCreateUpdateNotifierCRArn 
-      AWS Lambda function to send a notification when the new GovCloud account is created. This 
-      notification will make an HTTP POST to the API Gateway in the GovCloud Organization management 
-      account which executes an AWS Lambda function that completes the account onboarding process 
-      (invite to organization, accept invitation, move to correct OU and bootstrap) for the GovCloud 
-      account.
-    Properties:
-      ServiceToken: !Ref GovernanceAtScaleAccountFactoryGovCloudAccountCreateUpdateNotifierCRArn
-      AccountName: !Ref AccountName
-      AccountEmail: !Ref Email
-      ManagedOrganizationalUnit: !GetAtt GovCloudOUDetails.OrganizationalUnitName
-      AccountId: !GetAtt Account.govcloud_account_id
-      PuppetAccountId: !Ref GovCloudPuppetAccountId
-      AccountPartition: GovCloud
 
   AccountBootstrapConditionHandle1:
     Type: AWS::CloudFormation::WaitConditionHandle
@@ -287,7 +210,7 @@ Resources:
     DependsOn: AccountWaiter1
     Description: |
       A custom resource using the GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn 
-      AWS Lambda function to bootstrap the new Commercial account
+      AWS Lambda function to bootstrap the new account
     Properties:
       ServiceToken: !Ref GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn
       OrganizationAccountAccessRoleName: !Ref OrganizationAccountAccessRole
@@ -306,8 +229,5 @@ Resources:
 
 Outputs:
   AccountId:
-    Description: The Account ID for the new commercial account
+    Description: The ID of the new account
     Value: !GetAtt Account.account_id
-  GovCloudAccountId:
-    Description: The Account ID for the new GovCloud account
-    Value: !GetAtt Account.govcloud_account_id

--- a/governance-at-scale-account-factory/aws-service-catalog-govcloud-account-creation/v1/README.md
+++ b/governance-at-scale-account-factory/aws-service-catalog-govcloud-account-creation/v1/README.md
@@ -70,6 +70,9 @@ The list of parameters for this template:
 ### PuppetAccountId
 *Type:* String  
 *Description:* The account ID for the Commercial account where Service Catalog Puppet is installed
+### PuppetAccountAccessRoleName
+*Type:* String
+*Description:* The name of the role to that allows the current account to bootstrap a spoke against the Puppet account
 ### GovCloudPuppetAccountId
 *Type:* String  
 *Description:* The account ID for the GovCloud account where Service Catalog Puppet is installed

--- a/governance-at-scale-account-factory/govcloud-account-onboard/v1/README.md
+++ b/governance-at-scale-account-factory/govcloud-account-onboard/v1/README.md
@@ -17,10 +17,10 @@ The list of parameters for this template:
 *Type:* String  
 *Default:* OrganizationAccountAccessRole  
 *Description:* The name of the IAM Role used for cross account assess for AWS Organizations 
-### PuppetAccountAccessRole 
+### PuppetAccountAccessRoleArn 
 *Type:* String  
 *Default:* PuppetAccountAccessRole  
-*Description:* The name of the IAM Role used for cross account assess for bootstrapping Service Catalog Puppet
+*Description:* The ARN of the IAM Role used for cross account assess for bootstrapping Puppet
 ### BootstrapperProjectName 
 *Type:* String  
 *Default:* servicecatalog-puppet-single-account-bootstrapper  

--- a/governance-at-scale-account-factory/govcloud-account-onboard/v1/README.md
+++ b/governance-at-scale-account-factory/govcloud-account-onboard/v1/README.md
@@ -20,7 +20,7 @@ The list of parameters for this template:
 ### PuppetAccountAccessRole 
 *Type:* String  
 *Default:* PuppetAccountAccessRole  
-*Description:* The name of the IAM Role used for cross account assess for bootstrapping Puppet
+*Description:* The name of the IAM Role used for cross account assess for bootstrapping Service Catalog Puppet
 ### BootstrapperProjectName 
 *Type:* String  
 *Default:* servicecatalog-puppet-single-account-bootstrapper  

--- a/governance-at-scale-account-factory/manifest-govcloud.yaml
+++ b/governance-at-scale-account-factory/manifest-govcloud.yaml
@@ -1,3 +1,31 @@
+accounts:
+  - account_id: "SET_ME"
+    name: "puppet"
+    default_region: us-gov-west-1
+    regions_enabled:
+      - us-gov-west-1
+    tags:
+      - type:prod
+      - partition:aws-us-gov
+      - scope:puppet_account
+  - ou: "/SET_ME"
+    name: "organization-spokes"
+    default_region: us-gov-west-1
+    regions_enabled:
+      - us-gov-west-1
+    tags:
+      - type:prod
+      - partition:aws-us-gov
+      - scope:spoke
+  - account_id: "SET_ME"
+    name: "gov-organization-management"
+    default_region: us-gov-west-1
+    regions_enabled:
+      - us-gov-west-1
+    tags:
+      - type:prod
+      - partition:aws-us-gov
+      - scope:org_management
 launches:
   account-bootstrap-shared:
     depends_on:
@@ -14,15 +42,15 @@ launches:
       AssumableRoleArnInRootAccountForBootstrapping:
         ssm:
           name: /governance-at-scale-account-factory/account-bootstrap-shared-org-bootstrap/AssumableRoleArnInRootAccountForBootstrapping
-      GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName:
-        default: AccountBootstrapSharedBootstrapperIAMRoleName
-      GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName:
-        default: AccountBootstrapSharedCustomResourceIAMRoleName
+      ? GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName
+      : default: AccountBootstrapSharedBootstrapperIAMRoleName
+      ? GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName
+      : default: AccountBootstrapSharedCustomResourceIAMRoleName
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
     product: account-bootstrap-shared
-    version: v3
+    version: v4
   account-bootstrap-shared-org-bootstrap:
     deploy_to:
       tags:
@@ -33,49 +61,72 @@ launches:
         - param_name: /governance-at-scale-account-factory/account-bootstrap-shared-org-bootstrap/AssumableRoleArnInRootAccountForBootstrapping
           stack_output: AssumableRoleArnInRootAccountForBootstrapping
     parameters:
-      GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperOrgIAMRoleName:
-        default: AccountBootstrapSharedBootstrapperOrgIAMRoleName
+      ? GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperOrgIAMRoleName
+      : default: AccountBootstrapSharedBootstrapperOrgIAMRoleName
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
       OrganizationAccountAccessRole:
         default: OrganizationAccountAccessRole
       ServiceCatalogToolsAccountId:
-        default: SET_ME
-    portfolio: demo-central-it-team-portfolio
+        default: "SET_ME"
+    portfolio: gas-acct-factory
     product: account-bootstrap-shared-org-bootstrap
-    version: v1  
+    version: v1
   govcloud-account-onboard:
+    depends_on:
+      - account-puppet-org-bootstrap
+    deploy_to:
+      tags:
+        - regions: default_region
+          tag: scope:org_management
     parameters:
       OrganizationAccountAccessRole:
         default: OrganizationAccountAccessRole
-      PuppetAccountAccessRole:
-        default: PuppetAccountAccessRole
+      PuppetAccountAccessRoleArn:
+        ssm:
+          name: /governance-at-scale-account-factory/account-puppet-org-bootstrap/PuppetAccountAccessRoleArn
       BootstrapperProjectName:
         default: servicecatalog-puppet-single-account-bootstrapper
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactory-IAMRolePath/
       GovernanceAtScaleAccountFactoryAccountAccountInvitationIAMRoleName:
         default: AccountInvitationRole
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
     product: govcloud-account-onboard
     version: v1
+  account-puppet-org-bootstrap:
     deploy_to:
       tags:
-        - tag: scope:org_management
+        - tag: scope:puppet_account
           regions: default_region
-  govcloud-account-onboard-puppet-bootstrap:
+    outputs:
+      ssm:
+        - param_name: /governance-at-scale-account-factory/account-puppet-org-bootstrap/PuppetAccountAccessRoleArn
+          stack_output: AssumableRoleArnInPuppetAccountForBootstrapping
     parameters:
       OrganizationRootAccountId:
-        default: SET_ME
+        default: "SET_ME"
       OrganizationAccountAccessRole:
         default: OrganizationAccountAccessRole
       AccountOnboardPuppetRoleName:
         default: PuppetAccountAccessRole
-    portfolio: demo-central-it-team-portfolio
-    product: govcloud-account-onboard-puppet-bootstrap
+    portfolio: gas-acct-factory
+    product: account-puppet-org-bootstrap
     version: v1
+spoke-local-portfolios:
+  account-vending-for-spokes:
+    portfolio: gas-acct-factory
+    associations:
+      - arn:aws-us-gov:iam::${AWS::AccountId}:role/SET_ME
+    constraints:
+      launch:
+        - products:
+            - govcloud-account-onboard
+            - account-bootstrap-shared-org-bootstrap
+          roles:
+            - arn:aws-us-gov:iam::${AWS::AccountId}:role/SET_ME
     deploy_to:
       tags:
-        - tag: scope:puppet_account
-          regions: default_region  
+        - regions: default_region
+          tag: scope:org_management
 schema: puppet-2019-04-01

--- a/governance-at-scale-account-factory/manifest.yaml
+++ b/governance-at-scale-account-factory/manifest.yaml
@@ -1,3 +1,33 @@
+accounts:
+  - account_id: "SET_ME"
+    name: "puppet"
+    default_region: us-east-1
+    regions_enabled:
+      - us-east-1
+      - us-west-1
+    tags:
+      - type:prod
+      - partition:aws
+      - scope:puppet_account
+  - ou: "/SET_ME"
+    name: "organization-spokes"
+    default_region: us-east-1
+    regions_enabled:
+      - us-east-1
+      - us-west-1
+    tags:
+      - type:prod
+      - partition:aws
+      - scope:spoke
+  - account_id: "SET_ME"
+    name: "organization-management"
+    default_region: us-east-1
+    regions_enabled:
+      - us-east-1
+    tags:
+      - type:prod
+      - partition:aws
+      - scope:org_management
 launches:
   account-bootstrap-shared:
     depends_on:
@@ -6,6 +36,8 @@ launches:
       tags:
         - regions: default_region
           tag: scope:puppet_account
+        - regions: default_region
+          tag: scope:org_management
     outputs:
       ssm:
         - param_name: /governance-at-scale-account-factory/account-bootstrap-shared/GovernanceAtScaleAccountFactoryBootstrapperProjectCustomResourceArn
@@ -14,15 +46,15 @@ launches:
       AssumableRoleArnInRootAccountForBootstrapping:
         ssm:
           name: /governance-at-scale-account-factory/account-bootstrap-shared-org-bootstrap/AssumableRoleArnInRootAccountForBootstrapping
-      GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName:
-        default: AccountBootstrapSharedBootstrapperIAMRoleName
-      GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName:
-        default: AccountBootstrapSharedCustomResourceIAMRoleName
+      ? GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperIAMRoleName
+      : default: AccountBootstrapSharedBootstrapperIAMRoleName
+      ? GovernanceAtScaleAccountFactoryAccountBootstrapSharedCustomResourceIAMRoleName
+      : default: AccountBootstrapSharedCustomResourceIAMRoleName
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
     product: account-bootstrap-shared
-    version: v3
+    version: v4
   account-bootstrap-shared-org-bootstrap:
     deploy_to:
       tags:
@@ -33,15 +65,15 @@ launches:
         - param_name: /governance-at-scale-account-factory/account-bootstrap-shared-org-bootstrap/AssumableRoleArnInRootAccountForBootstrapping
           stack_output: AssumableRoleArnInRootAccountForBootstrapping
     parameters:
-      GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperOrgIAMRoleName:
-        default: AccountBootstrapSharedBootstrapperOrgIAMRoleName
+      ? GovernanceAtScaleAccountFactoryAccountBootstrapSharedBootstrapperOrgIAMRoleName
+      : default: AccountBootstrapSharedBootstrapperOrgIAMRoleName
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
       OrganizationAccountAccessRole:
         default: OrganizationAccountAccessRole
       ServiceCatalogToolsAccountId:
-        default: SET_ME
-    portfolio: demo-central-it-team-portfolio
+        default: "SET_ME"
+    portfolio: gas-acct-factory
     product: account-bootstrap-shared-org-bootstrap
     version: v1
   account-create-update-notifier:
@@ -62,7 +94,7 @@ launches:
         default: AccountCreateUpdateCRIAMRoleName
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
     product: account-create-update-notifier
     version: v2
   account-creation-notifier-cfh-handler:
@@ -82,7 +114,48 @@ launches:
         default: /AccountFactoryIAMRolePath/
       CFHAccountCreateUpdatePostUrl:
         default: https://example.com/intranet/teams/ccoe/products/account-factory/endpoint
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
+    product: account-creation-notifier-cfh-handler
+    version: v1
+  account-create-update-notifier-gov:
+    deploy_to:
+      tags:
+        - regions: default_region
+          tag: scope:org_management
+    outputs:
+      ssm:
+        - param_name: /governance-at-scale-account-factory/account-create-update-notifier-gov/AccountCreateUpdateNotifierTopicArn
+          stack_output: AccountCreateUpdateNotifierTopicArn
+        - param_name: /governance-at-scale-account-factory/account-create-update-notifier-gov/AccountCreateUpdateNotifierTopicName
+          stack_output: AccountCreateUpdateNotifierTopicName
+        - param_name: /governance-at-scale-account-factory/account-create-update-notifier-gov/GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn
+          stack_output: GovernanceAtScaleAccountFactoryAccountCreateUpdateNotifierCRArn
+    parameters:
+      GovernanceAtScaleAccountFactoryAccountCreateUpdateCRIAMRoleName:
+        default: AccountCreateUpdateCRIAMRoleName
+      GovernanceAtScaleAccountFactoryIAMRolePath:
+        default: /AccountFactoryIAMRolePath/
+    portfolio: gas-acct-factory
+    product: account-create-update-notifier
+    version: v2
+  account-creation-notifier-cfh-handler-gov:
+    depends_on:
+      - account-create-update-notifier-gov
+    deploy_to:
+      tags:
+        - regions: default_region
+          tag: scope:org_management
+    parameters:
+      AccountCreateUpdateNotifierTopicArn:
+        ssm:
+          name: /governance-at-scale-account-factory/account-create-update-notifier-gov/AccountCreateUpdateNotifierTopicArn
+      GovernanceAtScaleAccountFactoryAccountCreateUpdateCFHHandlerIAMRoleName:
+        default: AccountCreateUpdateCFHHandlerIAMRoleName
+      GovernanceAtScaleAccountFactoryIAMRolePath:
+        default: /AccountFactoryIAMRolePath/
+      CFHAccountCreateUpdatePostUrl:
+        default: https://example.com/intranet/teams/ccoe/products/account-factory/endpoint
+    portfolio: gas-acct-factory
     product: account-creation-notifier-cfh-handler
     version: v1
   account-creation-shared:
@@ -92,6 +165,8 @@ launches:
       tags:
         - regions: default_region
           tag: scope:puppet_account
+        - regions: default_region
+          tag: scope:org_management
     outputs:
       ssm:
         - param_name: /governance-at-scale-account-factory/account-creation-shared/GovernanceAtScaleAccountFactoryAccountCreationCRArn
@@ -104,7 +179,7 @@ launches:
           name: /governance-at-scale-account-factory/account-creation-shared-org-bootstrap/GovernanceAtScaleAccountFactoryAccountCreationSharedOrgRoleArn
       OrganizationAccountAccessRole:
         default: OrganizationAccountAccessRole
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
     product: account-creation-shared
     version: v5
   account-creation-shared-org-bootstrap:
@@ -124,8 +199,8 @@ launches:
       OrganizationAccountAccessRole:
         default: OrganizationAccountAccessRole
       ServiceCatalogToolsAccountId:
-        default: SET_ME
-    portfolio: demo-central-it-team-portfolio
+        default: "SET_ME"
+    portfolio: gas-acct-factory
     product: account-creation-shared-org-bootstrap
     version: v2
   account-details:
@@ -135,6 +210,8 @@ launches:
       tags:
         - regions: default_region
           tag: scope:puppet_account
+        - regions: default_region
+          tag: scope:org_management
     outputs:
       ssm:
         - param_name: /governance-at-scale-account-factory/account-details/GovernanceAtScaleAccountFactoryAccountDetailsCRArn
@@ -147,7 +224,7 @@ launches:
           name: /governance-at-scale-account-factory/account-details-org-bootstrap/GovernanceAtScaleAccountFactoryAccountDetailsOrgRoleArn
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
     product: account-details
     version: v1
   account-details-org-bootstrap:
@@ -165,15 +242,36 @@ launches:
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
       ServiceCatalogToolsAccountId:
-        default: SET_ME
-    portfolio: demo-central-it-team-portfolio
+        default: "SET_ME"
+    portfolio: gas-acct-factory
     product: account-details-org-bootstrap
+    version: v1
+  account-puppet-org-bootstrap:
+    deploy_to:
+      tags:
+        - regions: default_region
+          tag: scope:puppet_account
+    outputs:
+      ssm:
+        - param_name: /governance-at-scale-account-factory/account-puppet-org-bootstrap/PuppetAccountAccessRoleArn
+          stack_output: AssumableRoleArnInPuppetAccountForBootstrapping
+    parameters:
+      OrganizationRootAccountId:
+        default: "SET_ME"
+      OrganizationAccountAccessRole:
+        default: OrganizationAccountAccessRole
+      AccountOnboardPuppetRoleName:
+        default: PuppetAccountAccessRole
+    portfolio: gas-acct-factory
+    product: account-puppet-org-bootstrap
     version: v1
   account-type-to-organizational-unit-chooser:
     deploy_to:
       tags:
         - regions: default_region
           tag: scope:puppet_account
+        - regions: default_region
+          tag: scope:org_management
     outputs:
       ssm:
         - param_name: /governance-at-scale-account-factory/account-type-to-organizational-unit-chooser/GovernanceAtScaleAccountFactoryAccountTypeToOUChooserCRArn
@@ -183,7 +281,7 @@ launches:
         default: AccountTypeChooserCRIAMRoleName
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
-    portfolio: demo-central-it-team-portfolio
+    portfolio: gas-acct-factory
     product: account-type-to-organizational-unit-chooser
     version: v2
   account-waiter:
@@ -192,7 +290,9 @@ launches:
     deploy_to:
       tags:
         - regions: default_region
-          tag: role:puppethub
+          tag: scope:puppet_account
+        - regions: default_region
+          tag: scope:org_management
     parameters:
       GovernanceAtScaleAccountFactoryAccountCreationSharedOrgRoleArn:
         ssm:
@@ -200,14 +300,14 @@ launches:
       GovernanceAtScaleAccountFactoryIAMRolePath:
         default: /AccountFactoryIAMRolePath/
       ServiceCatalogPuppetVersion:
-        default: 0.91.0
+        default: SET_ME
       OrganizationAccountAccessRole:
         default: OrganizationAccountAccessRole
     outputs:
       ssm:
         - param_name: /governance-at-scale-account-factory/account-waiter/GovernanceAtScaleAccountFactoryAccountWaiterCRArn
           stack_output: GovernanceAtScaleAccountFactoryAccountWaiterCRArn
-    portfolio: example-account-vending-account-vending
+    portfolio: gas-acct-factory
     product: account-waiter
     version: v4
   move-to-ou:
@@ -216,7 +316,9 @@ launches:
     deploy_to:
       tags:
         - regions: default_region
-          tag: role:puppethub
+          tag: scope:puppet_account
+        - regions: default_region
+          tag: scope:org_management
     parameters:
       GovernanceAtScaleAccountFactoryAccountCreationSharedOrgRoleArn:
         ssm:
@@ -227,7 +329,23 @@ launches:
       ssm:
         - param_name: /governance-at-scale-account-factory/move-to-ou/GovernanceAtScaleAccountFactoryMoveToOUCRArn
           stack_output: GovernanceAtScaleAccountFactoryMoveToOUCRArn
-    portfolio: example-account-vending-account-vending
+    portfolio: gas-acct-factory
     product: move-to-ou
     version: v3
+spoke-local-portfolios:
+  account-vending-for-spokes:
+    portfolio: gas-acct-factory
+    associations:
+      - arn:aws:iam::${AWS::AccountId}:role/SET_ME
+    constraints:
+      launch:
+        - products:
+            - aws-service-catalog-account-creation
+            - aws-service-catalog-govcloud-account-creation
+          roles:
+            - arn:aws:iam::${AWS::AccountId}:role/SET_ME
+    deploy_to:
+      tags:
+        - regions: default_region
+          tag: scope:org_management
 schema: puppet-2019-04-01

--- a/governance-at-scale-account-factory/portfolio-govcloud.yaml
+++ b/governance-at-scale-account-factory/portfolio-govcloud.yaml
@@ -3,152 +3,152 @@
 
 Schema: factory-2019-04-01
 Portfolios:
-  Components:
-    - Description: account-bootstrap-shared
-      Distributor: CCOE
-      Name: account-bootstrap-shared
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-bootstrap-shared
-        Provider: CodeCommit
-      BuildSpec: |
-        version: 0.2
-        phases:
-          install:
-            runtime-versions:
-              python: 3.8
-          build:
-            commands:
-              - pip install -r requirements.txt -t src
-            {% for region in ALL_REGIONS %}
-              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-            {% endfor %}
-        artifacts:
-          files:
-            - '*'
-            - '**/*'
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an AWS CodeBuild project that can be run to bootstrap an account. 
-            It also includes an AWS Lambda function that can be used to back a custom resource 
-            so that the CodeBuild project can be started from AWS CloudFormation
-          Name: v3
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v3
-              RepositoryName: account-bootstrap-shared
-    - Description: account-bootstrap-shared-org-bootstrap
-      Distributor: CCOE
-      Name: account-bootstrap-shared-org-bootstrap
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-bootstrap-shared-org-bootstrap
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an IAM Role that is required to use AWS Organizations 
-            to bootstrap AWS accounts
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: account-bootstrap-shared-org-bootstrap
-    
-      Distributor: CCOE
-      Name: move-to-ou
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: move-to-ou
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Versions:
-        - Description: This product creates an AWS Lambda function that is used to move an 
-            AWS account to specified organizational unit (OU)
-          Name: v3
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v3
-              RepositoryName: move-to-ou
-      ProviderName: ccoe
-      Tags:
-        - Key: team
-          Value: ccoe
-    - Description: govcloud-account-onboard
-      Distributor: CCOE
-      Name: govcloud-account-onboard
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: govcloud-account-onboard
-        Provider: CodeCommit
-      BuildSpec: |
-        version: 0.2
-        phases:
-          install:
-            runtime-versions:
-              python: 3.8
-          build:
-            commands:
-              - pip install -r requirements.txt -t src
-            {% for region in ALL_REGIONS %}
-              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-            {% endfor %}
-        artifacts:
-          files:
-            - '*'
-            - '**/*'
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Versions:
-        - Description: 'This product creates a Lambda function with an API Gateway endpoint. 
-            The purpose of the Lambda function is to:
-            1. Add a newly created GovCloud account to the GovCloud organization through an 
-            automated invitation and handshake process
-            2. Move the account to the correct Organizational Unit (OU)
-            3. Bootstrap the account as a spoke of the GovCloud Service Catalog Puppet account'
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: govcloud-account-onboard
-    - Description: govcloud-account-onboard-puppet-bootstrap
-      Distributor: CCOE
-      Name: govcloud-account-onboard-puppet-bootstrap
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: govcloud-account-onboard-puppet-bootstrap
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Versions:
-        - Description: This product creates the IAM role that govcloud-account-onboard requires 
-            in order to bootstrap a new GovCloud account as a spoke of the GovCloud Service 
-            Catalog Puppet account
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: govcloud-account-onboard-puppet-bootstrap
-      ProviderName: ccoe
-      Tags:
-        - Key: team
-          Value: ccoe
+  - DisplayName: "gas-acct-factory"
+    Description: "G@S account vending machine"
+    ProviderName: "G@S-Team"
+    Tags:
+      - Key: "type"
+        Value: "governance"
+      - Key: "creator"
+        Value: "G@S-Team"
+    Components:
+      - Description: account-bootstrap-shared
+        Distributor: CCOE
+        Name: account-bootstrap-shared
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-bootstrap-shared
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.8
+            build:
+              commands:
+                - pip install -r requirements.txt -t src
+              {% for region in ALL_REGIONS %}
+                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+              {% endfor %}
+          artifacts:
+            files:
+              - '*'
+              - '**/*'
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an AWS CodeBuild project that can be run to bootstrap an account.
+              It also includes an AWS Lambda function that can be used to back a custom resource
+              so that the CodeBuild project can be started from AWS CloudFormation
+            Name: v4
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v4
+                RepositoryName: account-bootstrap-shared
+      - Description: account-bootstrap-shared-org-bootstrap
+        Distributor: CCOE
+        Name: account-bootstrap-shared-org-bootstrap
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-bootstrap-shared-org-bootstrap
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an IAM Role that is required to use AWS Organizations
+              to bootstrap AWS accounts
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: account-bootstrap-shared-org-bootstrap
+      - Description: govcloud-account-onboard
+        Distributor: CCOE
+        Name: govcloud-account-onboard
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: govcloud-account-onboard
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.8
+            build:
+              commands:
+                - pip install -r requirements.txt -t src
+              {% for region in ALL_REGIONS %}
+                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+              {% endfor %}
+          artifacts:
+            files:
+              - '*'
+              - '**/*'
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Versions:
+          - Description:
+              "This product creates a Lambda function with an API Gateway endpoint.
+              The purpose of the Lambda function is to
+              Add a newly created GovCloud account to the GovCloud organization through an
+              automated invitation and handshake process
+              Move the account to the correct Organizational Unit (OU)
+              Bootstrap the account as a spoke of the GovCloud Service Catalog Puppet account"
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: govcloud-account-onboard
+      - Description: account-puppet-org-bootstrap
+        Distributor: CCOE
+        Name: account-puppet-org-bootstrap
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-puppet-org-bootstrap
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Versions:
+          - Description:
+              This product creates the IAM role that govcloud-account-onboard requires
+              in order to bootstrap a new GovCloud account as a spoke of the GovCloud Service
+              Catalog Puppet account
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: account-puppet-org-bootstrap
+        ProviderName: ccoe
+        Tags:
+          - Key: team
+            Value: ccoe

--- a/governance-at-scale-account-factory/portfolio.yaml
+++ b/governance-at-scale-account-factory/portfolio.yaml
@@ -3,377 +3,468 @@
 
 Schema: factory-2019-04-01
 Portfolios:
-  Components:
-    - Description: account-bootstrap-shared
-      Distributor: CCOE
-      Name: account-bootstrap-shared
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-bootstrap-shared
-        Provider: CodeCommit
-      BuildSpec: |
-        version: 0.2
-        phases:
-          install:
-            runtime-versions:
-              python: 3.8
-          build:
-            commands:
-              - pip install -r requirements.txt -t src
-            {% for region in ALL_REGIONS %}
-              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-            {% endfor %}
-        artifacts:
-          files:
-            - '*'
-            - '**/*'
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an AWS CodeBuild project that can be run to bootstrap an account. 
-            It also includes an AWS Lambda function that can be used to back a custom resource 
-            so that the CodeBuild project can be started from AWS CloudFormation
-          Name: v3
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v3
-              RepositoryName: account-bootstrap-shared
-    - Description: account-bootstrap-shared-org-bootstrap
-      Distributor: CCOE
-      Name: account-bootstrap-shared-org-bootstrap
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-bootstrap-shared-org-bootstrap
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an IAM Role that is required to use AWS Organizations 
-            to bootstrap AWS accounts
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: account-bootstrap-shared-org-bootstrapaccount-creation-shared-org-bootstrap
-    - Description: account-create-update-notifier
-      Distributor: CCOE
-      Name: account-create-update-notifier
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-create-update-notifier
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an AWS Lambda function to back a custom resource 
-            that dispatches notifications to an included SNS Topic
-          Name: v2
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v2
-              RepositoryName: account-create-update-notifier
-    - Description: account-creation-notifier-cfh-handler
-      Distributor: CCOE
-      Name: account-creation-notifier-cfh-handler
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-creation-notifier-cfh-handler
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an AWS Lambda as a subscription to an SNS topic. 
-            The Lambda function is used to relay messages from SNS to a custom HTTP POST endpoint
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: account-creation-notifier-cfh-handler
-    - Description: account-creation-shared
-      Distributor: CCOE
-      Name: account-creation-shared
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-creation-shared
-        Provider: CodeCommit
-      BuildSpec: |
-        version: 0.2
-        phases:
-          install:
-            runtime-versions:
-              python: 3.8
-          build:
-            commands:
-              - pip install -r requirements.txt -t src
-            {% for region in ALL_REGIONS %}
-              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-            {% endfor %}
-        artifacts:
-          files:
-            - '*'
-            - '**/*'
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an AWS Lambda function for backing custom 
-            resources to create an AWS Account
-          Name: v5
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v5
-              RepositoryName: account-creation-shared
-    - Description: account-creation-shared-org-bootstrap
-      Distributor: CCOE
-      Name: account-creation-shared-org-bootstrap
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-creation-shared-org-bootstrap
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []  
-      Versions:
-        - Description: This product creates an IAM Role that is needed in order 
-            to use AWS Organizations to create AWS Accounts
-          Name: v2
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v2
-              RepositoryName: account-creation-shared-org-bootstrap
-    - Description: account-details
-      Distributor: CCOE
-      Name: account-details
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-details
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product takes a provided 'AccountName' and returns 
-            the details about that account
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: account-details
-    - Description: account-details-org-bootstrap
-      Distributor: CCOE
-      Name: account-details-org-bootstrap
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-details-org-bootstrap
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product creates an IAM Role that is needed to use 
-            AWS Organizations to list AWS Accounts.
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: account-details-org-bootstrap
-    - Description: account-type-to-organizational-unit-chooser
-      Distributor: CCOE
-      Name: account-type-to-organizational-unit-chooser
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-type-to-organizational-unit-chooser
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: This product takes the given account type and returns the 
-            organizational unit it should be assigned to
-          Name: v2
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v2
-              RepositoryName: account-type-to-organizational-unit-chooser
-    - Description: account-waiter
-      Distributor: CCOE
-      Name: account-waiter
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: account-waiter
-        Provider: CodeCommit
-      BuildSpec: |
-        version: 0.2
-        phases:
-          install:
-            runtime-versions:
-              python: 3.8
-          build:
-            commands:
-              - pip install -r requirements.txt -t src
-            {% for region in ALL_REGIONS %}
-              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-            {% endfor %}
-        artifacts:
-          files:
-            - '*'
-            - '**/*'
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Versions:
-        - Description: This product creates an AWS Lambda function for backing custom 
-            resources that will wait for CodeBuild and CloudFormation to become 
-            available in a newly created account
-          Name: v4
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v4
-              RepositoryName: account-waiter
-      ProviderName: ccoe
-      Tags:
-        - Key: team
-          Value: ccoe
-    - Description: aws-control-tower-account-factory
-      Distributor: CCOE
-      Name: aws-control-tower-account-factory
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: aws-control-tower-account-factory
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Tags: []
-      Versions:
-        - Description: Augments AWS Control Tower Account Factory - simplifies user input,
-            dispatches extra parameters via AWS SNS andreturns the account id as an output
-          Name: v1
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: aws-control-tower-account-factory
-    - Description: aws-service-catalog-account-creation
-      Distributor: CCOE
-      Name: aws-service-catalog-account-creation
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: aws-service-catalog-account-creation
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Versions:
-        - Description: This product is used to create a commercial AWS Account and bootstrap 
-            it using `aws-service-catalog-puppet` so you can provision products into the account
-          Name: v3
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v3
-              RepositoryName: aws-service-catalog-account-creation
-      ProviderName: ccoe
-      Tags:
-        - Key: team
-          Value: ccoe
-    - Description: aws-service-catalog-govcloud-account-creation
-      Distributor: CCOE
-      Name: aws-service-catalog-govcloud-account-creation
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: aws-service-catalog-govcloud-account-creation
-        Provider: CodeCommit
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Versions:
-        - Description: This product is used to create a new GovCloud account and the linked commercial AWS Accounts. 
-            The accounts will be moved to the organizational unit (OU) based on the provided account groups 
-            and account types. The new accounts will be bootstrapped with the Service Catalog Puppet 
-            account in the corresponding partition.
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v1
-              RepositoryName: aws-service-catalog-govcloud-account-creation
-      ProviderName: ccoe
-      Tags:
-        - Key: team
-          Value: ccoe
-    - Description: move-to-ou
-      Distributor: CCOE
-      Name: move-to-ou
-      Owner: CCOE@Example.com
-      Source:
-        Configuration:
-          RepositoryName: move-to-ou
-        Provider: CodeCommit
-      BuildSpec: |
-        version: 0.2
-        phases:
-          install:
-            runtime-versions:
-              python: 3.8
-          build:
-            commands:
-              - pip install -r requirements.txt -t src
-            {% for region in ALL_REGIONS %}
-              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-            {% endfor %}
-        artifacts:
-          files:
-            - '*'
-            - '**/*'
-      SupportDescription: Find us on Slack or Wiki
-      SupportEmail: ccoe-support@Example.com
-      SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
-      Versions:
-        - Description: This product creates an AWS Lambda function that is used to move an 
-            AWS account to specified organizational unit (OU)
-          Name: v3
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              BranchName: v3
-              RepositoryName: move-to-ou
-      ProviderName: ccoe
-      Tags:
-        - Key: team
-          Value: ccoe
+  - DisplayName: "gas-acct-factory"
+    Description: "G@S account vending machine"
+    ProviderName: "G@S-Team"
+    Tags:
+      - Key: "type"
+        Value: "governance"
+      - Key: "creator"
+        Value: "G@S-Team"
+    Components:
+      - Description: account-bootstrap-shared
+        Distributor: CCOE
+        Name: account-bootstrap-shared
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-bootstrap-shared
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.8
+            build:
+              commands:
+                - pip install -r requirements.txt -t src
+              {% for region in ALL_REGIONS %}
+                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+              {% endfor %}
+          artifacts:
+            files:
+              - '*'
+              - '**/*'
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an AWS CodeBuild project that can be run to bootstrap an account.
+              It also includes an AWS Lambda function that can be used to back a custom resource so that the
+              CodeBuild project can be started from AWS CloudFormation
+            Name: v4
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v4
+                RepositoryName: account-bootstrap-shared
+      - Description: account-bootstrap-shared-org-bootstrap
+        Distributor: CCOE
+        Name: account-bootstrap-shared-org-bootstrap
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-bootstrap-shared-org-bootstrap
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an IAM Role that is required to use AWS Organizations
+              to bootstrap AWS accounts
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: account-bootstrap-shared-org-bootstrap
+      - Description: account-create-update-notifier
+        Distributor: CCOE
+        Name: account-create-update-notifier
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-create-update-notifier
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an AWS Lambda function to back a custom resource
+              that dispatches notifications to an included SNS Topic
+            Name: v2
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v2
+                RepositoryName: account-create-update-notifier
+      - Description: account-creation-notifier-cfh-handler
+        Distributor: CCOE
+        Name: account-creation-notifier-cfh-handler
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-creation-notifier-cfh-handler
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an AWS Lambda as a subscription to an SNS topic.
+              The Lambda function is used to relay messages from SNS to a custom HTTP POST endpoint
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: account-creation-notifier-cfh-handler
+      - Description: account-creation-shared
+        Distributor: CCOE
+        Name: account-creation-shared
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-creation-shared
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.8
+            build:
+              commands:
+                - pip install -r requirements.txt -t src
+              {% for region in ALL_REGIONS %}
+                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+              {% endfor %}
+          artifacts:
+            files:
+              - '*'
+              - '**/*'
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an AWS Lambda function for backing custom
+              resources to create an AWS Account
+            Name: v5
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v5
+                RepositoryName: account-creation-shared
+      - Description: account-creation-shared-org-bootstrap
+        Distributor: CCOE
+        Name: account-creation-shared-org-bootstrap
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-creation-shared-org-bootstrap
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product creates an IAM Role that is needed in order
+              to use AWS Organizations to create AWS Accounts
+            Name: v2
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v2
+                RepositoryName: account-creation-shared-org-bootstrap
+      - Description: account-details
+        Distributor: CCOE
+        Name: account-details
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-details
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description: This product takes a provided 'AccountName' and returns
+              the details about that account
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: account-details
+      - Description: account-details-org-bootstrap
+        Distributor: CCOE
+        Name: account-details-org-bootstrap
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-details-org-bootstrap
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description: This product creates an IAM Role that is needed to use
+              AWS Organizations to list AWS Accounts.
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: account-details-org-bootstrap
+      - Description: account-puppet-org-bootstrap
+        Distributor: CCOE
+        Name: account-puppet-org-bootstrap
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-puppet-org-bootstrap
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Versions:
+          - Description:
+              This product creates an AWS Lambda function that is used to move an
+              AWS account to specified organizational unit (OU)
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: account-puppet-org-bootstrap
+        ProviderName: ccoe
+        Tags:
+          - Key: team
+            Value: ccoe
+      - Description: account-type-to-organizational-unit-chooser
+        Distributor: CCOE
+        Name: account-type-to-organizational-unit-chooser
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-type-to-organizational-unit-chooser
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              This product takes the given account type and returns the
+              organizational unit it should be assigned to
+            Name: v2
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v2
+                RepositoryName: account-type-to-organizational-unit-chooser
+      - Description: account-waiter
+        Distributor: CCOE
+        Name: account-waiter
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: account-waiter
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.8
+            build:
+              commands:
+                - pip install -r requirements.txt -t src
+              {% for region in ALL_REGIONS %}
+                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+              {% endfor %}
+          artifacts:
+            files:
+              - '*'
+              - '**/*'
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Versions:
+          - Description:
+              This product creates an AWS Lambda function for backing custom
+              resources that will wait for CodeBuild and CloudFormation to become
+              available in a newly created account
+            Name: v4
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v4
+                RepositoryName: account-waiter
+        ProviderName: ccoe
+        Tags:
+          - Key: team
+            Value: ccoe
+      - Description: aws-control-tower-account-factory
+        Distributor: CCOE
+        Name: aws-control-tower-account-factory
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: aws-control-tower-account-factory
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Tags: []
+        Versions:
+          - Description:
+              Augments AWS Control Tower Account Factory - simplifies user input,
+              dispatches extra parameters via AWS SNS andreturns the account id as an output
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: aws-control-tower-account-factory
+      - Description: aws-service-catalog-account-creation
+        Distributor: CCOE
+        Name: aws-service-catalog-account-creation
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: aws-service-catalog-account-creation
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Versions:
+          - Description:
+              This product is used to create a commercial AWS Account and bootstrap
+              it using `aws-service-catalog-puppet` so you can provision products into the account
+            Name: v4
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v4
+                RepositoryName: aws-service-catalog-account-creation
+        ProviderName: ccoe
+        Tags:
+          - Key: team
+            Value: ccoe
+      - Description: aws-service-catalog-govcloud-account-creation
+        Distributor: CCOE
+        Name: aws-service-catalog-govcloud-account-creation
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: aws-service-catalog-govcloud-account-creation
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Versions:
+          - Description:
+              This product is used to create a new GovCloud account and the linked commercial AWS Accounts.
+              The accounts will be moved to the organizational unit (OU) based on the provided account groups
+              and account types. The new accounts will be bootstrapped with the Service Catalog Puppet
+              account in the corresponding partition.
+            Name: v1
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v1
+                RepositoryName: aws-service-catalog-govcloud-account-creation
+        ProviderName: ccoe
+        Tags:
+          - Key: team
+            Value: ccoe
+      - Description: move-to-ou
+        Distributor: CCOE
+        Name: move-to-ou
+        Owner: CCOE@Example.com
+        Source:
+          Configuration:
+            RepositoryName: move-to-ou
+          Provider: CodeCommit
+        Constraints:
+          Launch:
+            LocalRoleName: SET_ME
+        BuildSpec: |
+          version: 0.2
+          phases:
+            install:
+              runtime-versions:
+                python: 3.8
+            build:
+              commands:
+                - pip install -r requirements.txt -t src
+              {% for region in ALL_REGIONS %}
+                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+              {% endfor %}
+          artifacts:
+            files:
+              - '*'
+              - '**/*'
+        SupportDescription: Find us on Slack or Wiki
+        SupportEmail: ccoe-support@Example.com
+        SupportUrl: https://example.com/intranet/teams/ccoe/products/account-factory
+        Versions:
+          - Description:
+              This product creates an AWS Lambda function that is used to move an
+              AWS account to specified organizational unit (OU)
+            Name: v3
+            Source:
+              Provider: CodeCommit
+              Configuration:
+                BranchName: v3
+                RepositoryName: move-to-ou
+        ProviderName: ccoe
+        Tags:
+          - Key: team
+            Value: ccoe


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This includes all the changes that were needed based on my testing. The solution now supports calling the bootstrap CodeBuild project across accounts. This was needed because GovCloud accounts can only be created from the Organization master and that is not usually going to be the same as the Puppet account. 

It also includes various fixes that were causing issues during deployments and updates to documentation as necessary. I created new manifest and portfolio files that are more thorough, have updated versions, consistent information and structure. These should now just require copy/paste and updating a few values which are mostly account IDs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
