### PR TITLE
instead of using Portfolios/Components, use Products and Portfolios separately

### DIFF
--- a/service-control-policy/manifest.yaml
+++ b/service-control-policy/manifest.yaml
@@ -5,7 +5,7 @@ schema: puppet-2019-04-01
 
 launches:
   scp-create-guardrail-001:
-    portfolio: demo-central-it-team-portfolio
+    portfolio: scp
     product: scp-create
     version: v1
     parameters:
@@ -32,7 +32,7 @@ launches:
         - param_name: /sc-outputs/scp-create-guardrail-001/PolicyId
           stack_output: PolicyId
   scp-attach-guardrail-001:
-    portfolio: demo-central-it-team-portfolio
+    portfolio: scp
     product: scp-attach
     version: v1
     depends_on:

--- a/service-control-policy/portfolio.yaml
+++ b/service-control-policy/portfolio.yaml
@@ -2,79 +2,92 @@
 # SPDX-License-Identifier: Apache-2.0
 
 Schema: factory-2019-04-01
+Products:
+  - Name: scp-create
+    Owner: infrastructure-team@customer.com
+    Description: Creates SCP
+    Distributor: IT-Support-Customer
+    SupportDescription: Contact us on Chime for help #central-it-team
+    SupportEmail: infrastructure-team@customer.com
+    SupportUrl: https://wiki.customer.com/infrastructure-team/self-service/
+    Tags:
+      - Key: lz-type
+        Value: core
+      - Key: product-type
+        Value: scp
+    Versions:
+      - Name: v1
+        Description: Creates SCP
+        Active: True
+        Source:
+          Provider: CodeCommit
+          Configuration:
+            RepositoryName: scp-create
+            BranchName: v1
+    BuildSpec: |
+        version: 0.2
+        phases:
+          install:
+            runtime-versions:
+              python: 3.8
+          build:
+            commands:
+              - for dir in src/*; do pip install -r $dir/requirements.txt -t $dir/; done
+            {% for region in ALL_REGIONS %}
+              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+            {% endfor %}
+        artifacts:
+          files:
+            - '*'
+            - '**/*'
+    Portfolios:
+      - "scp"
+  - Name: scp-attach
+    Owner: infrastructure-team@customer.com
+    Description: Attaches SCP
+    Distributor: IT-Support-Customer
+    SupportDescription: Contact us on Chime for help #central-it-team
+    SupportEmail: infrastructure-team@customer.com
+    SupportUrl: https://wiki.customer.com/infrastructure-team/self-service/
+    Tags:
+      - Key: lz-type
+        Value: core
+      - Key: product-type
+        Value: scp
+    Versions:
+      - Name: v1
+        Description: Attaches SCP
+        Active: True
+        Source:
+          Provider: CodeCommit
+          Configuration:
+            RepositoryName: scp-attach
+            BranchName: v1
+    BuildSpec: |
+        version: 0.2
+        phases:
+          install:
+            runtime-versions:
+              python: 3.8
+          build:
+            commands:
+              - for dir in src/*; do pip install -r $dir/requirements.txt -t $dir/; done
+            {% for region in ALL_REGIONS %}
+              - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
+            {% endfor %}
+        artifacts:
+          files:
+            - '*'
+            - '**/*'
+    Portfolios:
+      - "scp"
+
 Portfolios:
-  Components:
-    - Name: scp-create
-      Owner: infrastructure-team@customer.com
-      Description: Creates SCP
-      Distributor: IT-Support-Customer
-      SupportDescription: Contact us on Chime for help #central-it-team
-      SupportEmail: infrastructure-team@customer.com
-      SupportUrl: https://wiki.customer.com/infrastructure-team/self-service/
-      Tags:
-        - Key: lz-type
-          Value: core
-        - Key: product-type
-          Value: scp
-      Versions:
-        - Name: v1
-          Description: Creates SCP
-          Active: True
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              RepositoryName: scp-create
-              BranchName: master
-      BuildSpec: |
-          version: 0.2
-          phases:
-            install:
-              runtime-versions:
-                python: 3.8
-            build:
-              commands:
-                - for dir in src/*; do pip install -r $dir/requirements.txt -t $dir/; done
-              {% for region in ALL_REGIONS %}
-                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-              {% endfor %}
-          artifacts:
-            files:
-              - '*'
-              - '**/*'
-    - Name: scp-attach
-      Owner: infrastructure-team@customer.com
-      Description: Attaches SCP
-      Distributor: IT-Support-Customer
-      SupportDescription: Contact us on Chime for help #central-it-team
-      SupportEmail: infrastructure-team@customer.com
-      SupportUrl: https://wiki.customer.com/infrastructure-team/self-service/
-      Tags:
-        - Key: lz-type
-          Value: core
-        - Key: product-type
-          Value: scp
-      Versions:
-        - Name: v1
-          Description: Attaches SCP
-          Active: True
-          Source:
-            Provider: CodeCommit
-            Configuration:
-              RepositoryName: scp-attach
-              BranchName: master
-      BuildSpec: |
-          version: 0.2
-          phases:
-            install:
-              runtime-versions:
-                python: 3.8
-            build:
-              commands:
-                - for dir in src/*; do pip install -r $dir/requirements.txt -t $dir/; done
-              {% for region in ALL_REGIONS %}
-                - aws cloudformation package --template $(pwd)/product.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file product.template-{{ region }}.yaml
-              {% endfor %}
-          artifacts:
-            files:
-              - '*'
-              - '**/*'
+  - DisplayName: "scp"
+    Description: "Portfolio with Security Control Policies"
+    ProviderName: "IT-Support-Customer"
+    Associations:
+      - "arn:aws:iam::${AWS::AccountId}:role/TeamRole"
+    Tags:
+      - Key: "creator"
+        Value: "infrastructure-team@customer.com"


### PR DESCRIPTION
## Reason for this PR
Without this change, creating the Service Catalog Products results in the following error in `servicecatalog-factory-pipeline`:
```
[Container] 2021/06/25 10:25:56 Entering phase BUILD
[Container] 2021/06/25 10:25:56 Running command servicecatalog-factory --info generate-via-luigi portfolios/
INFO MainThread Generating
INFO MainThread Loading portfolio: portfolios//scp.yaml
INFO MainThread Checking for external config
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.7.10/bin/servicecatalog-factory", line 8, in <module>
    sys.exit(cli())
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/servicecatalog_factory/cli.py", line 38, in generate_via_luigi
    core.generate_via_luigi(p)
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/servicecatalog_factory/core.py", line 162, in generate_via_luigi
    portfolios = generate_portfolios(portfolios_file_path)
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/servicecatalog_factory/core.py", line 96, in generate_portfolios
    portfolio, portfolio_file_name, "Components
  File "/root/.pyenv/versions/3.7.10/lib/python3.7/site-packages/servicecatalog_factory/core.py", line 105, in check_for_external_definitions_for
    for component in portfolio.get(type, []):
AttributeError: 'str' object has no attribute 'get'
[Container] 2021/06/25 10:25:56 Command did not exit successfully servicecatalog-factory --info generate-via-luigi portfolios/ exit status 1
[Container] 2021/06/25 10:25:56 Phase complete: BUILD State: FAILED
[Container] 2021/06/25 10:25:56 Phase context status code: COMMAND_EXECUTION_ERROR Message: Error while executing command: servicecatalog-factory --info generate-via-luigi portfolios/. Reason: exit status 1
[Container] 2021/06/25 10:25:56 Entering phase POST_BUILD
```

Environment:
```
aws-service-catalog-factory==0.60.0
```

## Description of changes
1. The portfolio file, instead of starting it with:
```
Schema: factory-2019-04-01
Portfolios:
  Components:
```
let's start with:
```
Schema: factory-2019-04-01
Products:
```
and end with
```
Portfolios:
```
2. I also changed the `BranchName: master` for the 2 Service Catalog Products here to `BranchName: v1` to align with the [documentation](https://aws-service-catalog-factory.readthedocs.io/en/latest/factory/designing_your_product.html#product-versions)

----


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
