### PR TITLE
Addition of SNS Notifier for Codebuild build jobs

### DIFF
--- a/operations/codebuild-sns-notifier/README.md
+++ b/operations/codebuild-sns-notifier/README.md
@@ -1,0 +1,7 @@
+# CodeBuild SNS Notifier
+
+This solution creates an SNS notification for CodeBuild Jobs in the event that a build fails or is stopped.
+## Description
+* Deploys a single product in the tooling account that will trigger Cloudwatch events rule if a commit is made to a designated branch of all repositories in the designated AWS account
+* Product consists of CloudWatch Event rule that is triggered for a CodeBuild Build job in the event that a build fails or is stopped
+* SNS Topic and subscripton is created and Notification sent via E-mail when event occurs

--- a/operations/codebuild-sns-notifier/example-manifest.yaml
+++ b/operations/codebuild-sns-notifier/example-manifest.yaml
@@ -1,0 +1,12 @@
+schema: puppet-2019-04-01
+stacks:
+  code-commitbackups:
+    name: code-commit-backups
+    version: v1
+    parameters:
+      pServiceCatalogCodeCommitSnsNotifyEmail:
+        default: 'itops@company.com'
+    deploy_to:
+      tags:
+        - tag: role:sct
+          regions: default_region

--- a/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
+++ b/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
@@ -1,0 +1,75 @@
+# Copyright 2021 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+AWSTemplateFormatVersion: '2010-09-09'
+Description: |
+  Product that zips up code commit repo when a cloudwatch commit event occurs the zip is added to an s3 bucket.
+  {"framework": "servicecatalog-products", "role": "product", "product-set": "operations", "product": "codecommit-sns-notifier", "version": "v1"}
+
+Parameters:
+  pServiceCatalogCodeCommitSnsNotifyEmail:
+    Type: String
+    Description: Target E-mail address for SNS Notifications to be sent to
+
+Resources:
+# sns topic for notifications
+  rSnsTopic:
+    Type: AWS::SNS::Topic
+    Properties: 
+      DisplayName: codebuild-notify
+      TopicName: codebuild-notify
+
+  # sns subscription for notifications
+  rSnsSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint:
+        Ref: pServiceCatalogCodeCommitSnsNotifyEmail
+      Protocol: email
+      TopicArn:
+        Ref: rSnsTopic
+
+  # policy to allow cloudwatch to publish to sns
+  rEventTopicPolicy:
+    Type: 'AWS::SNS::TopicPolicy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Action: 'sns:Publish'
+            Resource: !Ref rSnsTopic
+      Topics:
+        - !Ref rSnsTopic
+
+  # SNS notification Cloudwatch rule
+  rCloudwatchNotifyRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Cloudwatch rule that watches for codebuild events
+      Name: codebuild-build-notify
+      EventPattern:
+        source:
+          - aws.codebuild
+        detail-type:
+          - CodeBuild Build State Change
+        detail:
+          build-status:
+            - FAILED
+            - STOPPED
+      Targets:
+        - Arn: !Ref rSnsTopic
+          Id: codebuild-trigger-notify
+          InputTransformer:
+            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status"}
+            InputTemplate: |
+              "Build '<build-id>' for build project '<project-name>' has reached the build status of '<build-status>'."
+
+Outputs:
+  oSnsTopic:
+    Description: SNS Topic Arn
+    Value: !Ref  rSnsTopic
+  oSnsSubscription:
+    Description: SNS Subscription Arn
+    Value: !Ref rSnsSubscription

--- a/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
+++ b/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
@@ -62,7 +62,7 @@ Resources:
         - Arn: !Ref rSnsTopic
           Id: codebuild-trigger-notify
           InputTransformer:
-            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status","account-id":"$.account","region":"$.region","stream-id":"$.detail.additional-information.logs.stream-name"}
+            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status","account-id":"$.account","region":"$.region","stream-id":"$.detail.additional-information.logs.stream-name"} #uses jsonpath to pull logstream 
             InputTemplate: | 
                 {"Build '<build-id>' for build project '<project-name>' has reached the build status of": <build-status>,
                 "BuildUrl": "https://console.aws.amazon.com/codesuite/codebuild/<account-id>/projects/<project-name>/build/<project-name>%3A<stream-id>/log?region=<region>",

--- a/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
+++ b/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
@@ -62,10 +62,10 @@ Resources:
         - Arn: !Ref rSnsTopic
           Id: codebuild-trigger-notify
           InputTransformer:
-            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status","account-id":"$.account","region":"$.region","deep-link":"$.detail.additional-information.logs.deep-link"}
+            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status","account-id":"$.account","region":"$.region","stream-id":"$.detail.additional-information.logs.stream-name"}
             InputTemplate: | 
                 {"Build '<build-id>' for build project '<project-name>' has reached the build status of": <build-status>,
-                "BuildUrl": <deep-link>,
+                "BuildUrl": "https://console.aws.amazon.com/codesuite/codebuild/<account-id>/projects/<project-name>/build/<project-name>%3A<stream-id>/log?region=<region>",
                 "AccountId": <account-id>,
                 "Region": <region>
                 }

--- a/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
+++ b/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
@@ -62,10 +62,11 @@ Resources:
         - Arn: !Ref rSnsTopic
           Id: codebuild-trigger-notify
           InputTransformer:
-            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status","account-id":"$.account","region":"$.region","stream-id":"$.detail.additional-information.logs.stream-name"} #uses jsonpath to pull logstream 
+            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status","account-id":"$.account","region":"$.region","stream-id":"$.detail.additional-information.logs.stream-name","cloudwatchlogs-url":"$.detail.additional-information.logs.deep-link"} #uses jsonpath to pull logstream 
             InputTemplate: | 
                 {"Build '<build-id>' for build project '<project-name>' has reached the build status of": <build-status>,
                 "BuildUrl": "https://console.aws.amazon.com/codesuite/codebuild/<account-id>/projects/<project-name>/build/<project-name>%3A<stream-id>/log?region=<region>",
+                "CloudWatchLogsUrl": <cloudwatchlogs-url>,
                 "AccountId": <account-id>,
                 "Region": <region>
                 }

--- a/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
+++ b/operations/codebuild-sns-notifier/stacks/codebuild-sns-notifier/v1/stack.template.yaml
@@ -3,7 +3,7 @@
 
 AWSTemplateFormatVersion: '2010-09-09'
 Description: |
-  Product that zips up code commit repo when a cloudwatch commit event occurs the zip is added to an s3 bucket.
+  Product that sends an SNS notification when a CodeBuild Build job succeeeds or fails.
   {"framework": "servicecatalog-products", "role": "product", "product-set": "operations", "product": "codecommit-sns-notifier", "version": "v1"}
 
 Parameters:
@@ -62,9 +62,13 @@ Resources:
         - Arn: !Ref rSnsTopic
           Id: codebuild-trigger-notify
           InputTransformer:
-            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status"}
-            InputTemplate: |
-              "Build '<build-id>' for build project '<project-name>' has reached the build status of '<build-status>'."
+            InputPathsMap: {"build-id":"$.detail.build-id","project-name":"$.detail.project-name","build-status":"$.detail.build-status","account-id":"$.account","region":"$.region","deep-link":"$.detail.additional-information.logs.deep-link"}
+            InputTemplate: | 
+                {"Build '<build-id>' for build project '<project-name>' has reached the build status of": <build-status>,
+                "BuildUrl": <deep-link>,
+                "AccountId": <account-id>,
+                "Region": <region>
+                }
 
 Outputs:
   oSnsTopic:


### PR DESCRIPTION


Description of changes: This product creates an SNS topic/subscription and Cloudwatch Events rule to notify users in the event that a Codebuild build job fails.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
